### PR TITLE
Fix missing axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "express": "^4.18.2",
     "puppeteer": "^22.8.2",
     "puppeteer-extra": "^3.3.6",
-    "puppeteer-extra-plugin-stealth": "^2.11.2"
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
+    "axios": "^1.6.7"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"


### PR DESCRIPTION
## Summary
- add axios as a dependency so scrape-server.js can run

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684357102bc083338f6bdb452dbdedfd